### PR TITLE
Cambio en el JWTProvider 

### DIFF
--- a/BackendEventickNow/src/main/java/com/EventickNow/security/dto/JwtDto.java
+++ b/BackendEventickNow/src/main/java/com/EventickNow/security/dto/JwtDto.java
@@ -9,12 +9,13 @@ public class JwtDto {
 	private String token;
     private String bearer = "Bearer";
     private String emailUsuario;
-    private Collection<? extends GrantedAuthority> authorities;
+    private Collection<? extends GrantedAuthority> autorities;
 
-    public JwtDto(String token, String emailUsuario, Collection<? extends GrantedAuthority> authorities) {
+    public JwtDto(String token, String emailUsuario, Collection<? extends GrantedAuthority> autorities) {
         this.token = token;
         this.emailUsuario = emailUsuario;
-        this.authorities = authorities;
+        this.autorities = autorities;
+        
     }
 
     public String getToken() {
@@ -41,11 +42,12 @@ public class JwtDto {
         this.emailUsuario = emailUsuario;
     }
 
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return authorities;
+    public Collection<? extends GrantedAuthority> getAutorities() {
+    	return autorities;
+    }
+    
+    public void setRol(Collection<? extends GrantedAuthority> autorities) {
+    	this.autorities = autorities;
     }
 
-    public void setAuthorities(Collection<? extends GrantedAuthority> authorities) {
-        this.authorities = authorities;
-    }
 }

--- a/BackendEventickNow/src/main/java/com/EventickNow/security/jwt/JwtProvider.java
+++ b/BackendEventickNow/src/main/java/com/EventickNow/security/jwt/JwtProvider.java
@@ -30,7 +30,7 @@ public class JwtProvider {
 	
 	public String genereteToken(Authentication authentication) {
 		UsuarioPrincipal usuarioPrincipal = (UsuarioPrincipal) authentication.getPrincipal(); 
-		return Jwts.builder().setSubject(usuarioPrincipal.getCorreoElectronico())
+		return Jwts.builder().setSubject(usuarioPrincipal.getRol().toString())
 				.setIssuedAt(new Date())
 				.setExpiration(new Date(new Date().getTime() + expiration * 1000))	
 				.signWith(SignatureAlgorithm.HS512, secret)


### PR DESCRIPTION
Cambio en JwtProvider para enviar el rol en lugar del email del usuario, con el fin de tomarlo en el login en el frontend y hacer la redirección de pantallas según el rol.